### PR TITLE
Version bump for mtl library

### DIFF
--- a/operational.cabal
+++ b/operational.cabal
@@ -1,5 +1,5 @@
 Name:               operational
-Version:            0.2.1.2
+Version:            0.2.1.3
 Synopsis:           Implementation of difficult monads made easy
                     with operational semantics.
 Description:
@@ -35,7 +35,7 @@ source-repository head
 
 Library
     hs-source-dirs:     src
-    build-depends:      base == 4.* , mtl >= 1.1 && < 2.1.0
+    build-depends:      base == 4.* , mtl >= 1.1 && < 2.2.0
     ghc-options:        -Wall
     extensions:         GADTs, UndecidableInstances,
                         MultiParamTypeClasses, FlexibleInstances


### PR DESCRIPTION
Hey Heinrich,

This pull request includes a patch that bumps the (strict) upper bound on the mtl library dependency from 2.1.0 to 2.2.0.  This is needed because the version of mtl currently being packaged in the Haskell Platform is 2.1.1, and so at the moment operational uses one version of mtl while most other packages use another version.

I didn't see any test suite but the TicTacToe game seems to work just fine.
