### PR TITLE
Correct base bounds

### DIFF
--- a/operational.cabal
+++ b/operational.cabal
@@ -38,10 +38,10 @@ source-repository head
 
 Library
     hs-source-dirs:     src
-    build-depends:      base == 4.* , mtl >= 1.1 && < 2.4.0
+    build-depends:      base >= 4.4 && <5 , mtl >= 1.1 && < 2.4.0
     ghc-options:        -Wall
     extensions:         GADTs, Rank2Types, ScopedTypeVariables,
-                        UndecidableInstances,
+                        UndecidableInstances, GADTSyntax,
                         MultiParamTypeClasses, FlexibleInstances
     exposed-modules:    Control.Monad.Operational
 


### PR DESCRIPTION
Build fails on GHC 7.0 because `GADTSyntax` is introduced only in GHC 7.2.

While it isn't necessary to bound `base` bound, as it's not buildable with it (= not testable), so I'd say it's a right thing to do.

Alternatively you could revert to use `GADTs` extension, test with GHC-7.0, and relax the `base` lower bound.