### PR TITLE
Add MFunctor instances

### DIFF
--- a/operational.cabal
+++ b/operational.cabal
@@ -62,6 +62,7 @@ Library
     build-depends:      base >= 4.8 && < 5
                       , mtl >= 1.1 && < 2.4
                       , transformers >=0.5.6 && <0.7
+                      , mmorph >= 1.2 && < 1.3
     ghc-options:        -Wall
 
 Executable operational-TicTacToe

--- a/src/Control/Monad/Operational.hs
+++ b/src/Control/Monad/Operational.hs
@@ -24,6 +24,7 @@ module Control.Monad.Operational (
 
 import Control.Monad
 import Control.Monad.Identity (Identity, runIdentity)
+import Control.Monad.Morph    (MonadTrans(..), MFunctor(..), MMonad (..))
 import Control.Monad.Trans    (MonadTrans, lift)
 
     -- mtl  classes to instantiate.
@@ -218,6 +219,16 @@ instance Monad m => Applicative (ProgramT instr m) where
     pure   = return
     (<*>)  = ap
 
+instance MFunctor (ProgramT instr) where
+    hoist nat (Lift   m) = Lift (nat m)
+    hoist nat (Bind m f) = Bind (hoist nat m) (hoist nat . f)
+    hoist _   (Instr  i) = Instr i
+
+instance MMonad (ProgramT instr) where
+  embed lifting (Lift   m) = lifting m
+  embed lifting (Bind m f) = Bind (embed lifting m) (embed lifting . f)
+  embed _       (Instr  i) = Instr i
+
 -- | Program made from a single primitive instruction.
 singleton :: instr a -> ProgramT instr m a
 singleton = Instr
@@ -248,6 +259,10 @@ instance Monad m => Monad (ProgramViewT instr m) where
     return = Return
     Return a >>= cont = cont a
     (instr :>>= cont1) >>= cont2 = instr :>>= (cont1 >=> unviewT . cont2)
+
+instance MFunctor (ProgramViewT instr) where
+    hoist _ (Return a) = Return a
+    hoist morphism (instruction :>>= continuation) = instruction :>>= (hoist morphism . continuation)
 
 -- | View function for inspecting the first instruction.
 viewT :: Monad m => ProgramT instr m a -> m (ProgramViewT instr m a)


### PR DESCRIPTION
The idea behind `MFunctor` is that `ProgramT` and `ProgramViewT` should be compatible with functions like `lift :: MonadTrans t => m x -> t m x`, `liftIO :: MonadIO m => IO x -> m x`, `flip evalStateT s :: StateT s m a -> m a`, `flip runReaderT r :: ReaderT r m a -> m a`, and so on. Such functions are "monad morphisms", and `hoist` allows to use them on the inner monad of an operational construction.

For example, `hoist liftIO :: MonadIO m => ProgramT instr IO a -> ProgramT instr m a`.

Another typical use case is when you want to handle some part of your monad stack inside `ProgramT`, i.e. `hoist $ flip runReaderT r :: ProgramT (ReaderT r m) a -> ProgramT m a`.

I often need functions like this.

# To do

* [ ] Haddocks