### PR TITLE
Support mtl-2.3.1 (needed for GHC 9.6)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,13 +27,14 @@ jobs:
         ghc:
           - 8.10.7
           - 9.0.2
-          - 9.2.2
+          - 9.2.5
+          - 9.4.4
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Environment
-        uses: haskell/actions/setup@v1.2
+        uses: haskell/actions/setup@v2
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}
@@ -53,7 +54,7 @@ jobs:
           cabal freeze
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
           key: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - reopened
   push:
     branches:
-      - main
+      - master
   schedule:
     # Run once per day (at UTC 00:00) to maintain cache:
     - cron: 0 0 * * *
@@ -95,7 +95,7 @@ jobs:
       - name: Deploy
         if: |
             false
-            && github.ref == 'refs/heads/main'
+            && github.ref == 'refs/heads/master'
             && matrix.os == 'ubuntu-latest'
             && matrix.ghc == '8.10.7'
         uses: JamesIves/github-pages-deploy-action@v4.3.3

--- a/operational.cabal
+++ b/operational.cabal
@@ -56,7 +56,7 @@ Library
     hs-source-dirs:     src
     exposed-modules:    Control.Monad.Operational
 
-    build-depends:      base >= 4.8 && < 5, mtl >= 1.1 && < 2.3.0
+    build-depends:      base >= 4.8 && < 5, mtl >= 1.1 && < 2.4, transformers
     ghc-options:        -Wall
 
 Executable operational-TicTacToe

--- a/operational.cabal
+++ b/operational.cabal
@@ -41,7 +41,7 @@ flag buildExamples
 
 source-repository head
     type:           git
-    location:       git://github.com/HeinrichApfelmus/operational.git
+    location:       https://github.com/HeinrichApfelmus/operational.git
 
 Library
     default-language:   Haskell2010

--- a/src/Control/Monad/Operational.hs
+++ b/src/Control/Monad/Operational.hs
@@ -22,13 +22,15 @@ module Control.Monad.Operational (
 
     ) where
 
-import Control.Monad.Identity
-import Control.Monad.Trans
+import Control.Monad
+import Control.Monad.Identity (Identity, runIdentity)
+import Control.Monad.Trans    (MonadTrans, lift)
 
     -- mtl  classes to instantiate.
     -- Those commented out cannot be instantiated. For reasons see below.
 -- import Control.Monad.Cont.Class
 -- import Control.Monad.Error.Class
+import Control.Monad.IO.Class
 import Control.Monad.Reader.Class
 import Control.Monad.State.Class
 -- import Control.Monad.Writer.Class
@@ -293,7 +295,7 @@ interpretWithMonadT interpreter = go
         instruction :>>= continuation -> interpreter instruction >>= (go . continuation)
 
 -- | Utilitiy function for mapping a 'ProgramViewT' back into a 'ProgramT'.
--- 
+--
 -- Semantically, the function 'unviewT' is an inverse of 'viewT',
 -- e.g. we have
 --


### PR DESCRIPTION
`mtl-2.3.1` dropped reexports from `Control.Monad`. So
- `import Control.Monad`
- qualified import from `mtl` modules to avoid warnings about unused imports on `mtl-2.2`
- Make dep. `transformers`  explicit for GHC 7.10, as there `base` does not yet export `Control.Monad.IO.Class`

Also in this PR:
- update CI to latest version
- fix git link in cabal file